### PR TITLE
gui: precompress assets (.gz + .br) and serve via Caddy

### DIFF
--- a/ansible/templates/Caddyfile.j2
+++ b/ansible/templates/Caddyfile.j2
@@ -26,7 +26,9 @@
 	handle {
 		root * {{ gui_deploy_path }}
 		try_files {path} /index.html
-		file_server
+		file_server {
+			precompressed br gzip
+		}
 	}
 
 	# Security headers

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite",
     "dev:full": "concurrently \"pnpm dev\" \"cd ../../relay && go run cmd/relay/main.go\"",
-    "build": "tsc && vite build",
+    "build": "tsc && vite build && node ./scripts/precompress.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/packages/gui/scripts/precompress.mjs
+++ b/packages/gui/scripts/precompress.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import zlib from 'node:zlib';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const DIST_DIR = path.resolve(__dirname, '..', 'dist');
+const INCLUDE_RE = /\.(js|mjs|css|html|svg|json|wasm)$/i;
+
+function* walk(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walk(full);
+    } else {
+      yield full;
+    }
+  }
+}
+
+async function compressFileStream(srcPath, algo) {
+  const outExt = algo === 'gzip' ? '.gz' : '.br';
+  const dstPath = srcPath + outExt;
+  if (fs.existsSync(dstPath)) return { skipped: true, dstPath };
+
+  const read = fs.createReadStream(srcPath);
+  const write = fs.createWriteStream(dstPath);
+  const stream = algo === 'gzip'
+    ? zlib.createGzip({ level: 9 })
+    : zlib.createBrotliCompress({ params: { [zlib.constants.BROTLI_PARAM_QUALITY]: 11 } });
+
+  await pipeline(read, stream, write);
+  return { skipped: false, dstPath };
+}
+
+async function main() {
+  if (!fs.existsSync(DIST_DIR)) {
+    console.error(`[precompress] Dist directory not found: ${DIST_DIR}`);
+    process.exit(1);
+  }
+
+  const files = Array.from(walk(DIST_DIR))
+    .filter(f => INCLUDE_RE.test(f) && !f.endsWith('.gz') && !f.endsWith('.br'));
+
+  let total = 0, gz = 0, br = 0;
+  for (const file of files) {
+    total++;
+    try {
+      const r1 = await compressFileStream(file, 'gzip');
+      if (!r1.skipped) gz++;
+      const r2 = await compressFileStream(file, 'br');
+      if (!r2.skipped) br++;
+      process.stdout.write(`.`);
+    } catch (e) {
+      console.error(`\n[precompress] Failed for ${file}:`, e?.message || e);
+    }
+  }
+  console.log(`\n[precompress] Done. Processed: ${total}, new .gz: ${gz}, new .br: ${br}`);
+}
+
+main().catch(err => {
+  console.error('[precompress] Fatal error:', err);
+  process.exit(1);
+});
+


### PR DESCRIPTION
This PR adds post-build precompression for the GUI and enables precompressed serving in Caddy.\n\nSummary\n- Adds ESM precompression script to emit both .gz and .br alongside originals (keeps uncompressed).\n- Wires precompression into the GUI build (Vite) without adding new dependencies.\n- Configures Caddy file_server to serve precompressed variants (br, then gzip) automatically.\n\nDetails\n- Script: packages/gui/scripts/precompress.mjs\n  - Compresses: .js, .mjs, .css, .html, .svg, .json, .wasm\n  - Uses Node zlib streams; keeps originals intact\n- Build: packages/gui/package.json\n  - build: tsc && vite build && node ./scripts/precompress.mjs\n- Caddy: ansible/templates/Caddyfile.j2\n  - file_server { precompressed br gzip } under the SPA handle\n\nWhy\n- We need triple outputs (uncompressed, gzip, brotli) for deployment and external needs.\n- Precompressed serving reduces CPU on origin and improves TTFB for static assets.\n\nVerification\n- Local build produced both .gz and .br for all targeted assets.\n- Caddy will negotiate Content-Encoding based on Accept-Encoding; originals remain as a fallback.\n\nAcceptance\n- dist contains .gz and .br variants next to originals.\n- Caddy serves br when supported, otherwise gzip, otherwise identity.\n\nNo dependency changes; minimal and focused changes.\n