### PR TITLE
ci(release): integrate Changesets for versioning + publishing

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "master",
   "updateInternalDependencies": "patch",
   "ignore": []

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,12 +1,7 @@
 name: release + publish
 on:
+  # Keep manual trigger only to avoid double publishing; Changesets handles automatic releases
   workflow_dispatch:
-  push:
-    branches:
-      - 'master'
-    paths:
-      - 'packages/**'
-      - '.github/workflows/publish-packages.yml'
 
 jobs:
   build:

--- a/.github/workflows/release-changesets.yml
+++ b/.github/workflows/release-changesets.yml
@@ -5,6 +5,11 @@ on:
     branches: [ master ]
   workflow_dispatch:
 
+# Ensure the action can create PRs and push version commits
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -47,4 +52,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-

--- a/.github/workflows/release-changesets.yml
+++ b/.github/workflows/release-changesets.yml
@@ -1,0 +1,50 @@
+name: release (changesets)
+
+on:
+  push:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Rust Toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-unknown
+          override: true
+
+      - name: Install wasm-pack
+        run: cargo install wasm-pack
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build workspace
+        run: pnpm -r build
+
+      - name: Create Release PR or Publish
+        uses: changesets/action@v1
+        with:
+          publish: pnpm run release
+          version: pnpm run version:packages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "@changesets/cli": "2.27.9"
   },
   "scripts": {
-    "build": "pnpm -r build"
+    "build": "pnpm -r build",
+    "changeset": "changeset",
+    "version:packages": "changeset version && pnpm -r install --lockfile-only && pnpm -r build",
+    "release": "pnpm -r build && changeset publish"
   },
   "devDependencies": {
     "changeset": "^0.2.6",


### PR DESCRIPTION
This wires Changesets end-to-end for the monorepo.\n\nSummary\n- Set Changesets access to public (npm publish for scoped packages)\n- Root scripts:\n  - changeset (add changesets)\n  - version:packages (apply changesets + rebuild)\n  - release (workspace build + changeset publish)\n- New workflow: release (changesets)\n  - Node + pnpm + Rust toolchain + wasm-pack\n  - Install, build, and run changesets/action (creates version PRs or publishes)\n- Legacy publish workflow now manual (workflow_dispatch only) to avoid double-publishing\n\nNotes\n- Existing changeset (.changeset/pretty-impalas-explain.md) will be picked up on next run, creating a version PR.\n- NPM_TOKEN and GITHUB_TOKEN must be present in repo secrets.\n- GUI remains private; only public packages (core, wrapper) are published.\n\nSOP\n1) pnpm changeset (select packages + bump)\n2) Merge feature PRs\n3) Changesets bot opens a version PR — merge it\n4) CI publishes to npm via changesets\n